### PR TITLE
show detailed error messages for invalid form inputs

### DIFF
--- a/apps/faqcheck/lib/faqcheck/sources/strategies/rrfb_client_resources.ex
+++ b/apps/faqcheck/lib/faqcheck/sources/strategies/rrfb_client_resources.ex
@@ -94,7 +94,9 @@ defmodule Faqcheck.Sources.Strategies.RRFBClientResources do
       result = processor.(data)
       Ecto.Changeset.put_change(changeset, key, result)
     rescue
-      e -> Ecto.Changeset.add_error(changeset, key, Exception.message(e), data: data)
+      e -> Ecto.Changeset.add_error(
+        changeset, key, Exception.message(e),
+	data: data, error: e, stacktrace: __STACKTRACE__)
     end
   end
 end

--- a/apps/faqcheck_web/lib/faqcheck_web/router.ex
+++ b/apps/faqcheck_web/lib/faqcheck_web/router.ex
@@ -9,8 +9,8 @@ defmodule FaqcheckWeb.Router do
     plug :fetch_live_flash
     plug :protect_from_forgery
     plug :put_secure_browser_headers
-    # plug PowAssent.Plug.Reauthorization,
-    #   handler: PowAssent.Phoenix.ReauthorizationPlugHandler
+    plug PowAssent.Plug.Reauthorization,
+      handler: PowAssent.Phoenix.ReauthorizationPlugHandler
     #   %{"content-security-policy" => "default-src 'self';"}
     # plug :fetch_current_user
     plug :put_root_layout, {FaqcheckWeb.LayoutView, :root}


### PR DESCRIPTION
Fixes #5 

Gives a `<details>` block which lets you expand the full stack trace where the input couldn't be processed. The `try_process` thing should get lifted out to a helper function available to all strategies.