### PR TITLE
surface errors encountered when loading strategy data

### DIFF
--- a/apps/faqcheck/lib/faqcheck/sources/strategies.ex
+++ b/apps/faqcheck/lib/faqcheck/sources/strategies.ex
@@ -21,9 +21,15 @@ defmodule Faqcheck.Sources.Strategies do
 
   def build_changesets(strategy, feed, index) do
     {page, _ix} = Enum.at(feed.pages, index)
-    changesets = strategy.to_changesets(feed, page)
-    |> Stream.map(fn cs -> %{cs | action: :validate} end)
-    |> Enum.with_index()
-    {page, changesets}
+    case strategy.to_changesets(feed, page) do
+      {:ok, changesets} ->
+	{:ok,
+	 {page,
+	  changesets
+	  |> Stream.map(fn cs -> %{cs | action: :validate} end)
+	  |> Enum.with_index()}}
+      {:error, error} ->
+	{:error, error}
+    end
   end
 end

--- a/apps/faqcheck/lib/faqcheck/sources/strategies/nmcrg_xlsx_to_facilities.ex
+++ b/apps/faqcheck/lib/faqcheck/sources/strategies/nmcrg_xlsx_to_facilities.ex
@@ -28,7 +28,7 @@ defmodule Faqcheck.Sources.Strategies.NMCommunityResourceGuideXLSX do
   def to_changesets(
     _feed,
     %Sources.Upload{storage_path: storage_path}) do
-    XlsxHelpers.map_xlsx(storage_path, &row_changeset/1)
+    {:ok, XlsxHelpers.map_xlsx(storage_path, &row_changeset/1)}
   end
 
   defp row_changeset(row) do

--- a/apps/faqcheck/lib/faqcheck/sources/strategies/rrfb_client_resources.ex
+++ b/apps/faqcheck/lib/faqcheck/sources/strategies/rrfb_client_resources.ex
@@ -44,11 +44,14 @@ defmodule Faqcheck.Sources.Strategies.RRFBClientResources do
     case API.Excel.used_range token,
       drive_id, entry_id, worksheet_id do
       {:ok, %{"values" => values}} when is_nil(values) ->
-        []
+        {:ok, []}
       {:ok, %{"values" => values}} ->
-        values
-        |> filter_rows()
-        |> Enum.map(&row_to_changeset/1)
+        {:ok,
+	 values
+         |> filter_rows()
+         |> Enum.map(&row_to_changeset/1)}
+      {:error, {type, message}} ->
+	{:error, "couldn't load sheet '#{category}' from the Microsoft API: #{message} (#{type})"}
     end
   end
 

--- a/apps/faqcheck_web/lib/faqcheck_web/live/facility_import_live.ex
+++ b/apps/faqcheck_web/lib/faqcheck_web/live/facility_import_live.ex
@@ -75,8 +75,8 @@ defmodule FaqcheckWeb.FacilityImportLive do
     socket = assign_user(socket, session)
     strategy = Strategies.get!(strategy_id)
 
-    with {:ok, feed} <- Strategies.build_feed(strategy, data, build_session(strategy, socket, session)) do
-      {page, changesets} = Strategies.build_changesets(strategy, feed, 0)
+    with {:ok, feed} <- Strategies.build_feed(strategy, data, build_session(strategy, socket, session)),
+      {:ok, {page, changesets}} <- Strategies.build_changesets(strategy, feed, 0) do
       {:ok,
        socket
        |> assign(


### PR DESCRIPTION
Previously this would just silently fail when a page couldn't be loaded (e.g. timeout) or there was some other error reaching the data source.

"Fixes" https://github.com/csboling/faqcheck/issues/18 in that the user should now at least see some information about what went wrong in a case like this (the sheet couldn't be loaded in 10 seconds because it accidentally had >16,000 columns)