### PR TITLE
return to current page after successful login

### DIFF
--- a/apps/faqcheck_web/lib/faqcheck_web/templates/layout/root.html.leex
+++ b/apps/faqcheck_web/lib/faqcheck_web/templates/layout/root.html.leex
@@ -28,7 +28,7 @@
     	      <li><%= gettext("Signed in as: ") <> @current_user.email %></li>
     	      <li><%= link "Log out", to: Routes.sign_in_path(@conn, :index, @locale) %></li>
     	    <% else %>
-    	      <li><%= link "Log in", to: Routes.sign_in_path(@conn, :index, @locale) %></li>
+    	      <li><%= link "Log in", to: Routes.sign_in_path(@conn, :index, @locale, request_path: @conn.request_path) %></li>
     	    <% end %>
     	  </ul>
 


### PR DESCRIPTION
This was working if the app required you to log in, but just clicking "Log in" in the navbar would always take you to the homepage after login, instead of back to the page you were already visiting.