### PR TITLE
weird workaround for pow_assent logout DELETE method issues

### DIFF
--- a/apps/faqcheck_web/lib/faqcheck_web/controllers/close_session_controller.ex
+++ b/apps/faqcheck_web/lib/faqcheck_web/controllers/close_session_controller.ex
@@ -1,0 +1,7 @@
+defmodule FaqcheckWeb.CloseSessionController do
+  use FaqcheckWeb, :controller
+
+  def close(conn, _params) do
+    text(conn, "ok")
+  end
+end

--- a/apps/faqcheck_web/lib/faqcheck_web/pow/controller_callbacks.ex
+++ b/apps/faqcheck_web/lib/faqcheck_web/pow/controller_callbacks.ex
@@ -10,7 +10,7 @@ defmodule FaqcheckWeb.Pow.ControllerCallbacks do
     conn =
       conn
       |> Conn.put_session(:current_user_id, user.id)
-      |> Conn.put_session(@live_socket_id_key, "users_sockets:#{user.id}")
+      |> Conn.put_session(@live_socket_id_key, "users_socket:#{user.id}")
 
     ControllerCallbacks.before_respond(
       Pow.Phoenix.SessionController,
@@ -22,7 +22,9 @@ defmodule FaqcheckWeb.Pow.ControllerCallbacks do
 
   def before_respond(Pow.Phoenix.SessionController, :delete, {:ok, conn}, config) do
     live_socket_id = Conn.get_session(conn, @live_socket_id_key)
-    FaqcheckWeb.Endpoint.broadcast(live_socket_id, "disconnect", %{})
+    if !is_nil(live_socket_id) do
+      FaqcheckWeb.Endpoint.broadcast(live_socket_id, "disconnect", %{})
+    end
     ControllerCallbacks.before_respond(
       Pow.Phoenix.SessionController,
       :delete,

--- a/apps/faqcheck_web/lib/faqcheck_web/router.ex
+++ b/apps/faqcheck_web/lib/faqcheck_web/router.ex
@@ -65,9 +65,10 @@ defmodule FaqcheckWeb.Router do
     pipe_through :browser
     get "/", PageController, :dummy
 
+    delete "/session/new", CloseSessionController, :close
+
     get "/microsoft-callback", OidcController, :microsoft_callback
     get "/google-callback", OidcController, :microsoft_callback
-
   end
 
   scope "/", FaqcheckWeb do

--- a/apps/faqcheck_web/lib/faqcheck_web/templates/sign_in/index.html.eex
+++ b/apps/faqcheck_web/lib/faqcheck_web/templates/sign_in/index.html.eex
@@ -1,4 +1,24 @@
 <h1><%= gettext "User authentication" %></h1>
 
+<%= if is_nil(@conn.assigns.current_user) do %>
 <%= for link <- FaqcheckWeb.Pow.ViewHelpers.provider_links(@conn, request_path: @request_path),
   do: content_tag(:span, link) %>
+<% else %>
+<button id="signout"><%= gettext "Sign out" %></button>
+<script>
+document.getElementById('signout').onclick = function() {
+  fetch(
+    '/session',
+    {
+      method: 'DELETE',
+      headers: {
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+      },
+    },
+  )
+    .then(res => {
+      window.location.href = '/';
+    });
+};
+</script>
+<% end %>


### PR DESCRIPTION
Fixes https://github.com/csboling/faqcheck/issues/60

PowAssent has some assumptions about the flow of HTTP methods through signout routes that either are broken, or that other routing stuff (locales etc.) in this app breaks. This is the only way I was able to get it to work:

- button click triggers a Javascript `fetch` with `DELETE` method
- redirects lead to to `DELETE /session/new`, which pow_assent doesn't register
- so we set up a controller for this that just returns "ok", then
- `window.location.href = '/';`

Gross but functional.